### PR TITLE
fix no_delete typo

### DIFF
--- a/githubcollective/sync.py
+++ b/githubcollective/sync.py
@@ -14,7 +14,7 @@ class Sync(object):
         self.github = github
         self.verbose = verbose
         self.pretend = pretend
-        self.not_delete = no_delete
+        self.no_delete = no_delete
 
     def run(self, new, old):
 


### PR DESCRIPTION
To fix error encountered when using `-D`,

```
AttributeError: 'Sync' object has no attribute 'no_delete'
```
